### PR TITLE
Updated and added BOM, price estimates, and manufacturer numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Side Note: This design really needs to have 2 10nF capacitors on each encoder(CH
 - 2x Knobs with an inner diameter of 6mm and an outer diameter of between 20-25mm.  Can purchase or 3D print, preferably via resin.  Knob takes a m4x12 setscrew/grubscrew or shorter.  Probably go m4x10.  Or omit it entirely, it's a very tight fit.
 - 7x MX-compatible keycaps, in the sizes: 1x 1u, 4x 1.25/1.5u, 2x 2u.  Can purchase or 3D print, preferably via resin.
 - 4x small rubber feet, 10mm diameter
+- 1x USB micro to USB type A cable, you likely have dozens of these already.
 
 ## Optional Parts/Upgrades
 - 2x 2u Cherry MX Clip-in Stabilizers CHERRY 0G990224: https://www.mouser.com/ProductDetail/540-G99-0224 (Screw in stabs might fit as well, untested)
@@ -57,7 +58,7 @@ Side Note: This design really needs to have 2 10nF capacitors on each encoder(CH
 - ![Pocket SDVX Pico THT 10](pics/20210724_023411.jpg)
 
 
-
+<!--
 ## Probably your BOM, FYI I haven't bought these yet so YMMV
 - $12 - 1x Case printed at a library, makerspace, or maybe try https://www.reddit.com/r/3Dprintmything/
 - $0 - 5x PCB free from AllPCB https://www.allpcb.com/activity/free-pcb-prototype-2021.html
@@ -72,7 +73,61 @@ Side Note: This design really needs to have 2 10nF capacitors on each encoder(CH
 - $2.19 - 4x rubber feet, but you get 50 for 2 bucks ish https://www.ebay.com/itm/124679886620
 
 The sum: $60.79 plus tax
+-->
 
+## BOM 
+| Name             |Order Qty.  |Price (USD)|Ext.: (USD)|Manufacturer Num.  |Manufacturer|Description                                                                 |
+|------------------|------------|-----------|-----------|-------------------|------------|----------------------------------------------------------------------------|
+|Encoders          |2           |$2.00      |$4.00      |PEC16-2015F-N0024  |Bourns      |Encoders 15 MM SHAFT NO SWITCH NO DET                                       |
+|Pi Pico           |1           |$4.00      |$4.00      |SC0915             |Raspberry Pi|Single Board Computers Raspberry Pi Pico (No Headers)                       |
+|19mmx20mm Knobs   |2           |$5.08      |$10.16     |KB700B14AL         |Apem        |Knobs & Dials Machined Alumin Knob                                          |
+|MX 2U Stabilizers |2           |$0.23      |$0.46      |0G990224           |CHERRY      |Switch Hardware 1x2 KEYCAP W/FRAME                                          |
+|Knob LEDs         |2           |$0.36      |$0.72      |WP914IDT           |Kingbright  |Standard LEDs - Through Hole **Red** 625nm Diffused 8mcd. 2x3x4mm           |
+|Button LEDs       |5           |$0.37      |$1.85      |WP914GDT           |Kingbright  |Standard LEDs - Through Hole **Green** 568nm Diffused 6mcd. 2x3x4mm         |
+|Resistors         |7           |$0.32      |$2.24      |MOS1/2CT52R101J    |KOA Speer   |Metal Oxide Resistors 1/2W 100 5%                                           |
+|Capacitors        |4           |$0.22      |$0.88      |K103K10X7RF5UL2    |Vishay      |Multilayer Ceramic Capacitors MLCC - Leaded K 50V 10NF +/-10% X7R AMMO E3   |
+|MX Switches       |7           |$1.59      |$11.13     |MX3A-11NA          |CHERRY      |Cherry MX **Black**, clear housing  (Buy whatever switch type you prefer)   |
+|Keycaps           |1 (set)     |$19.99     |$19.99     | N/A               | N/A        |Need 5x 1u for BT, 2x 2u for FX. (Optimally 4x 1.5u, 2x 2.5u, 1x 1u)        |
+|USB Cable         |1           |$7.50      |$7.50      | N/A               | N/A        |USB Type A Male to Micro USB male. Purchase off Amazon or electronics store |
+|Rubber Feet       |100 (need 4)|$0.052     |$12.87     | N/A               | N/A        |Adhesive rubber pads. 3/8" diameter (~9.5mm). Try Amazon, or hardware store |
+|Case              |1           |$19.96     |$19.96     | N/A               | N/A        |Print at library or makerspace. PLA Price quote from https://www.hubs.com/. ABS may have fitment issues with switches. Resin is optimal but 2-3x the price.      |
+|PCB               |5 (need 1)  |$9.00      |$45.00     | N/A               | N/A        |MINIMUM sets of 5 PCBs. Price quote from https://www.allpcb.com/            |
+
+
+Sum (excluding shipping and tax): $140.76
+
+All components with a listed Manufacturer Number has an uploadable BOM to Mouser and/or Digikey found in `bom/`. Components which do not have a listed number must be ordered wherever you can find them.
+
+## Reduced Cost BOM
+While the original sum may seem pricey, a majority of the cost is from the Case, Keycaps, and Knobs (all of which can be 3D printed) as well as the PCBs (which can be subsidized if you or someone you know makes more than one Pico THT). Additional cost savings can be accounted for if you already own these components, or buy them in bulk (such as the MX switches). Below is a more accurate projection of price per controller assuming you:
+1. Have access to a large enough FDM 3D printer which prints in PLA filament, or SLA printer which prints in resin. These have costs about $25.00 per 1kg spool/container.
+2. Obtained a spare PCB from a friend or acquaintance, or got lucky and found a manufacturer promotion for free PCBs.
+3. Bought or own the MX Switches, and Rubber Feet in bulk from a previous project and/or plan to use them in other projects.
+4. Have a surplus of USB cables.
+
+Changes are bolded and marked in `[#]`
+
+| Name             |Order Qty.  |Price (USD)|Ext.: (USD)|Manufacturer Num.  |Manufacturer|Description                                                                 |
+|------------------|------------|-----------|-----------|-------------------|------------|----------------------------------------------------------------------------|
+|Encoders          |2           |$2.00      |$4.00      |PEC16-2015F-N0024  |Bourns      |Encoders 15 MM SHAFT NO SWITCH NO DET                                       |
+|Pi Pico           |1           |$4.00      |$4.00      |SC0915             |Raspberry Pi|Single Board Computers Raspberry Pi Pico (No Headers)                       |
+|**22mmx20mm Knobs [1]**|2      |**$0.35**  |**$0.70**  | N/A (3D)          |N/A (3D)    |3D printed, ~14g = ~1/71 of a spool/container.                              |
+|MX 2U Stabilizers |2           |$0.23      |$0.46      |0G990224           |CHERRY      |Switch Hardware 1x2 KEYCAP W/FRAME                                          |
+|Knob LEDs         |2           |$0.36      |$0.72      |WP914IDT           |Kingbright  |Standard LEDs - Through Hole **Red** 625nm Diffused 8mcd. 2x3x4mm           |
+|Button LEDs       |5           |$0.37      |$1.85      |WP914GDT           |Kingbright  |Standard LEDs - Through Hole **Green** 568nm Diffused 6mcd. 2x3x4mm         |
+|Resistors         |7           |$0.32      |$2.24      |MOS1/2CT52R101J    |KOA Speer   |Metal Oxide Resistors 1/2W 100 5%                                           |
+|Capacitors        |4           |$0.22      |$0.88      |K103K10X7RF5UL2    |Vishay      |Multilayer Ceramic Capacitors MLCC - Leaded K 50V 10NF +/-10% X7R AMMO E3   |
+|**MX Switches [1]**|7          |**$0.27**  |**$2.40**  | (Gateron Yellows) |Gateron     |Most switches at ~$0.27 when buying in 100+. or ~$0.35 for 50+.             |
+|**Keycaps  [1]**  |1 (set)     |**$0.36**  |**$0.36**  | N/A (3D)          | N/A (3D)   |3D printed (4x 1.5u, 2x 2.5u, 1x 1u), ~14.5g = ~1/69 of a spool/container.  |
+|**USB Cable [4]** |1           |**$0.00**  |**$0.00**  | N/A               | N/A        |You probably have lots. Be sure they arent USB power only (no data transmit)|
+|**Rubber Feet [3]**|4          |**$0.052** |**$0.21**  | N/A               | N/A        |Adhesive rubber pads. 3/8" diameter (~9.5mm). Try Amazon, or hardware store.|
+|**Case   [1]**    |1           |**$2.25**  |**$2.25**  | N/A (3D)          | N/A (3D)   |3D printer, ~90g = ~1/11 of a spool/container.                              |
+|**PCB    [2]**    |1           |**$0.00**  |**$0.00**  | N/A               | N/A        |Obtained from friend or acquaintence, or a manufacturer had a free promo.   |
+
+Sum (excluding shipping and tax): $1​7.83
+
+Parts from either BOM can be modified as seen fit, for example keeping aluminum knobs for their feel or going to commericial 3D printing solutions if your print bed isnt big enough to 3D print the case. 
+<!--
 ## My BOM
 - $0 - 1x Case printed free at my local library
 - $0 - 5x PCB free from AllPCB
@@ -87,3 +142,4 @@ The sum: $60.79 plus tax
 - $0.08 - 4x feet (1/50)*4
 
 The sum: $14.59, half of which is overpriced knobs
+-->

--- a/bom/Pocket-Pico-THT-BOM-Digikey.csv
+++ b/bom/Pocket-Pico-THT-BOM-Digikey.csv
@@ -1,0 +1,10 @@
+﻿Index,Manufacturer Part Number,Manufacturer Name,Description,Availability,Stock Status,Attrition %,Requested Quantity 1,Pack Quantity 1,Pack Type 1,Digi-Key Part Number 1,Unit Price 1,Extended Price 1,Minimum Order Quantity 1,Datasheet,Original Part numbers
+1,,,,,,,,,,,,,,,Mfr. #
+2,PEC16-2015F-N0024,Bourns Inc.,ROTARY ENCODER MECHANICAL 24PPR,0,Normally Stocking,,2,2,Tray,118-PEC16-2015F-N0024-ND,1.52000,$3.04,1,https://www.bourns.com/docs/Product-Datasheets/pec16.pdf,PEC16-2015F-N0024
+3,SC0915,Raspberry Pi,RASPBERRY PI PICO RP2040 BOARD,"24,260",In Stock,,1,1,Cut Tape (CT),2648-SC0915CT-ND,4.00000,$4.00,1,https://datasheets.raspberrypi.com/pico/pico-datasheet.pdf,SC0915
+4,KB700B14AL,APEM Inc.,"KNOB KNURLED 0.250"" METAL",,Non-Stock,,2,1000,Bag,KB700B14AL-ND,3.65418,"$3,654.18",1000,,KB700B14AL
+5,0G990224,Cherry Americas LLC,KEYBOARD LEVMECH 8MM 1X2,868,In Stock,,2,2,Bulk,0G990224-ND,0.23000,$0.46,1,,0G990224
+6,WP914IDT,Kingbright,LED RED DIFFUSED THROUGH HOLE,"258,381",In Stock,,2,2,Bulk,754-1901-ND,0.39000,$0.78,1,https://www.KingbrightUSA.com/images/catalog/SPEC/WP914IDT.pdf,WP914IDT
+7,WP914GDT,Kingbright,LED GREEN DIFFUSED THROUGH HOLE,"11,650",In Stock,,5,5,Bulk,754-1900-ND,0.39000,$1.95,1,https://www.KingbrightUSA.com/images/catalog/SPEC/WP914GDT.pdf,WP914GDT
+8,K103K10X7RF5UH5,Vishay Beyschlag/Draloric/BC Components,CAP CER 10000PF 50V X7R RADIAL,"162,170",In Stock,,4,4,Cut Tape (CT),BC2662CT-ND,0.22000,$0.88,1,https://www.vishay.com/docs/45171/kseries.pdf,K103K10X7RF5UL2
+9,RSF100JB-73-100R,YAGEO,RES 100 OHM 5% 1W AXIAL,"16,597",In Stock,,7,7,Bulk,100W-1-ND,0.32000,$2.24,1,https://www.yageo.com/upload/media/product/productsearch/datasheet/lr/YAGEO%20RSF_datasheet_2021v0.pdf,RSF100JB-73-100R

--- a/bom/Pocket-Pico-THT-BOM-Mouser.csv
+++ b/bom/Pocket-Pico-THT-BOM-Mouser.csv
@@ -1,0 +1,15 @@
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+POCKET SDVX PICO THT,,,,,,
+Mfr. #,Mouser #,Manufacturer,Description,Order Qty.,Price (USD),Ext.: (USD)
+PEC16-2015F-N0024,652-PEC162015F-N0024,Bourns,Encoders 15 MM SHAFT NO SWITCH NO DET,2,$2.00,$4.00
+SC0915,358-SC0915,Raspberry Pi,Single Board Computers Raspberry Pi Pico (No Headers),1,$4.00,$4.00
+KB700B14AL,642-KB700B14AL,Apem,Knobs & Dials Machined Alumin Knob,2,$5.08,$10.16
+0G990224,540-G99-0224,CHERRY,Switch Hardware 1x2 KEYCAP W/FRAME,2,$0.23,$0.46
+WP914IDT,604-WP914IDT,Kingbright,Standard LEDs - Through Hole Red 625nm Diffused 8mcd,2,$0.36,$0.72
+WP914GDT,604-WP914GDT,Kingbright,Standard LEDs - Through Hole Green 568nm Diffused 6mcd,5,$0.37,$1.85
+282-100-RC,282-100-RC,Xicon,Metal Oxide Resistors 100ohms 5% Tol,100,$0.048,$4.80
+K103K10X7RF5UL2,594-K103K10X7RF5UL2,Vishay,Multilayer Ceramic Capacitors MLCC - Leaded K 50V 10NF +/-10% X7R AMMO E3,4,$0.22,$0.88

--- a/bom/README.md
+++ b/bom/README.md
@@ -1,0 +1,19 @@
+# Bill of Materials
+Various Bill of Materials are available here to purchase electronics. You can import these to Mouser or Digikey to easily purchase components in bulk via "import lists" tools on each respective website. Minor price variations and component availability exists between each site. 
+
+**NOT INCLUDED WITHIN BILL OF MATERIALS**:
+- MX Switches
+- Keycaps
+- Rubber Feet
+- Case
+- PCB
+- USB Cable
+
+**INCLUDED WITHIN BILL OF MATERIALS**:
+- Encoders, PEC16-2015F-N0024
+- Pi Pico
+- 22mm x 20mm Aluminum knobs
+- Cherry MX 2u Stabilizers
+- 2mmx3mmx4mm LEDs (Red for knobs, Green for switches. Try "Search Similar" feature if different colors desired)
+- Resistors, 100 ohm
+- Capacitors, 10 nF


### PR DESCRIPTION
Updated the README to have include BOM with price estimates and manufacturer number. Mainly due to expired ebay/aliexpress links. You previous BOM is still in the README, just commented out. I tried my best reflecting calculation methods from your bom via the "Reduced Cost BOM".

Additionally, added Bill of Materials for electronics in `bom/`. The spreadsheets in there are compatible with Mouser or Digikey's import tool. If alternate sources are found — say for example Bourns encoders or LEDs— I'll likely be updating these spreadsheets.